### PR TITLE
Adds auth0-instrumentation to capture usage metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/index.js
+++ b/index.js
@@ -1,8 +1,13 @@
+var agent = require('auth0-instrumentation');
+var pkg = require('./package.json');
 var fs = require('fs');
 var dirname = require('path').dirname;
 var conciergeFile = dirname(__dirname) + '/concierge.json';
 
 module.exports = function(context) {
+  var env = { METRICS_API_KEY: context.config.METRICS_API_KEY, METRICS_PREFIX: 'auth0' };
+  agent.init(pkg, env);
+
   // Initialize concierge on first run
   try {
     fs.accessSync(conciergeFile, fs.F_OK);
@@ -21,6 +26,7 @@ module.exports = function(context) {
         var list = fs.readFileSync(conciergeFile);
         list = JSON.parse(list);
 
+        agent.metrics.increment('concierge.messages', 1, { from: req.from.name, channel: req.channel.name, concierge: list[req.channel.name] || 'unassigned'});
         if (!list[req.channel.name]) {
           return res.text('No concierge assigned for this channel. Use `@concierge assign @user`').send();
         }

--- a/package.json
+++ b/package.json
@@ -16,5 +16,8 @@
   "bugs": {
     "url": "https://github.com/auth0/concierge-droid/issues"
   },
-  "homepage": "https://github.com/auth0/concierge-droid#readme"
+  "homepage": "https://github.com/auth0/concierge-droid#readme",
+  "dependencies": {
+    "auth0-instrumentation": "auth0/auth0-instrumentation#v2.1.0"
+  }
 }


### PR DESCRIPTION
This PR adds [auth0-instrumentation](https://github.com/auth0/auth0-instrumentation) in order to send usage metrics to DataDog. If the variable METRICS_API_KEY is not set, the flow continues as usual without crashing the process.