### PR TITLE
Check for concierge presence before pinging them

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 var agent = require('auth0-instrumentation');
+var slackApiClient = require('./lib/slack-api-client');
 var pkg = require('./package.json');
 var fs = require('fs');
 var dirname = require('path').dirname;
@@ -20,6 +21,8 @@ module.exports = function(context) {
     }
   }
 
+  var apiClient = slackApiClient.init(context.config.SLACK_API_TOKEN);
+
   return {
     callConcierge: function(req, res) {
       try {
@@ -37,11 +40,19 @@ module.exports = function(context) {
           return res.text(inChannelMatch[1] + ' :point_up:').send();
         }
         else {
-          var link = 'https://auth0.slack.com/archives/' + req.channel.name + '/p' + req.message.timestamp.replace('.', '');
-          var conciergeMessage = '@' + req.from.name + ' needs your attention in #' + req.channel.name + ' (' + link + ') \n\n*Message*:\n';
-          res.text(conciergeMessage + req.message.value.text, list[req.channel.name]);
-
-          return res.text('A message has been sent to the concierge (`' + list[req.channel.name] + '`). If your message is urgent and you don\'t receive a reply within 15 minutes, please use `@here` or `@channel`.').send();
+          var conciergeName = list[req.channel.name];
+          apiClient.getUserPresence(conciergeName, (err, isActive) => {
+            if(err) agent.logger.error("Error while getting user presence", { err });
+            if (err || isActive) {
+              var link = 'https://auth0.slack.com/archives/' + req.channel.name + '/p' + req.message.timestamp.replace('.', '');
+              var conciergeMessage = '@' + req.from.name + ' needs your attention in #' + req.channel.name + ' (' + link + ') \n\n*Message*:\n';
+              res.text(conciergeMessage + req.message.value.text, list[req.channel.name]);
+              return res.text('A message has been sent to the concierge (`' + conciergeName + '`). If your message is urgent and you don\'t receive a reply within 15 minutes, please use `@here` or `@channel`.').send();
+            } else {
+              var sanitizedConciergeName = conciergeName.replace('o', '0').replace('a', '4').replace('e', '3');
+              return res.text("Hey, it appears that the concierge is offline right now. If this is *really* urgent, please contact `@" + sanitizedConciergeName + "@ directly or use `@here` or `@channel`.").send();
+            }
+          });
         }
       } catch (e) {
         return res.text('An error has occurred while trying to contact the concierge.\n```' + JSON.stringify(e) + '```').send();

--- a/lib/slack-api-client.js
+++ b/lib/slack-api-client.js
@@ -1,0 +1,26 @@
+var WebClient = require('@slack/client').WebClient;
+
+exports.init = function init(token) {
+  this.client = new WebClient(token);
+}
+
+// Checks if the user is currently active
+// Needs a token with the `users:read` scope
+// https://api.slack.com/docs/presence-and-status
+exports.getUserPresence = function getUserPresence(username, cb) {
+  var userId;
+  web.users.list((err, res) => {
+    for(var i=0; i<res.members.length; i++) {
+      if(res.members[i].name === username) {
+        userId = res.members[i].id;
+      }
+    }
+
+    if(!userId) return cb(null, false);
+    return web.users.getPresence(userId, (errPresence, resPresence) => {
+      cb(errPresence, resPresence && resPresence.presence === 'active');
+    });
+  });
+}
+
+

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "homepage": "https://github.com/auth0/concierge-droid#readme",
   "dependencies": {
-    "auth0-instrumentation": "auth0/auth0-instrumentation#v2.1.0"
+    "auth0-instrumentation": "auth0/auth0-instrumentation#v2.1.0",
+    "@slack/client": "^3.9.0"
   }
 }


### PR DESCRIPTION
Checks for concierge presence (to see if they are online or not) instead of pinging them directly. This will require an API key. I had no way of testing this myself through the bot, but this test script worked:

```js
var WebClient = require('@slack/client').WebClient;

var token = process.env.SLACK_API_TOKEN || '';
var user = process.argv[2];
var web = new WebClient(token);

web.users.list((err, res) => {
  for(var i=0; i<res.members.length; i++) {
    if(res.members[i].name === user) {
      var userId = res.members[i].id;
      web.users.getPresence(userId, (errPresence, resPresence) => {
        console.log(resPresence.presence === 'active');
      });
    }
  }
});
```

By the way: we do have an "Office Hours" field in Slack but it's free text so we would need to parse, etc. This should be good as a first step.