### PR TITLE
Assign concierge to channels

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,9 +95,6 @@ module.exports = function(context) {
         list = JSON.parse(list);
 
         var name = req.params.name;
-        if (name.charAt(0) !== '@') {
-          name = '@' + name;
-        }
 
         // We can't DM subteams, so there's no point in allowing this
         var subteamMatch = name.match(/(@[^\s+]*)\(subteam\^.*\)/);


### PR DESCRIPTION
By removing the `@` char, we can use concierge using channels. This way, concierge messages are tracked in a separate channel specific for concierge questions.