### PR TITLE
add action: set welcome message

### DIFF
--- a/droid.json
+++ b/droid.json
@@ -43,6 +43,17 @@
       "premessage": "_Assigning concierge for this channel_"
     },
     {
+      "function": "setWelcomeMessage",
+      "aliases": [
+        "set welcome message:?\\s:message([\\s\\S]*)"
+      ],
+      "acls": {
+        "dm": false,
+        "mention": true
+      },
+      "premessage": "_Setting welcome message for concierge for this channel_"
+    },
+    {
       "function": "clearConcierge",
       "aliases": ["stop: on-call", "stop on-call"],
       "acls": {


### PR DESCRIPTION
This PR adds concierge support for showing a specific message when it is called.
Since the "store" for the channels with concierge only contains strings, after this PR the store will contain strings or objects (concierge name + welcome message) for each channel. 

We could migrate the store on starting as well and work always with objects, for now I have a compatibility check inside a `getConcierge()` function.

Example of use:
<img width="592" alt="screen shot 2017-07-15 at 12 21 11 pm" src="https://user-images.githubusercontent.com/1424663/28238824-77a8980c-695c-11e7-9b04-24db0cb2059b.png">

<img width="956" alt="screen shot 2017-07-15 at 12 46 22 pm" src="https://user-images.githubusercontent.com/1424663/28238825-7e2924c6-695c-11e7-94bf-6387d4454c64.png">
