### PR TITLE
Fixes #19 - Config is not defined when no settings added

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var dirname = require('path').dirname;
 var conciergeFile = dirname(__dirname) + '/concierge.json';
 
 module.exports = function(context) {
+  context.config = context.config || {};
   var env = { METRICS_API_KEY: context.config.METRICS_API_KEY, METRICS_PREFIX: 'auth0' };
   agent.init(pkg, env);
 


### PR DESCRIPTION
If no settings were added, the config object is undefined. This causes an exception when initializing concierge.

Closes #19 